### PR TITLE
Implementation of hash map with offheap `CharSequence` as key

### DIFF
--- a/benchmarks/src/main/java/org/questdb/Utf8StringIntHashMapBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/Utf8StringIntHashMapBenchmark.java
@@ -26,9 +26,11 @@ package org.questdb;
 
 import io.questdb.std.CharSequenceIntHashMap;
 import io.questdb.std.Misc;
+import io.questdb.std.OffHeapCharSequenceIntHashMap;
 import io.questdb.std.Utf8StringIntHashMap;
 import io.questdb.std.str.*;
 import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
@@ -43,13 +45,17 @@ public class Utf8StringIntHashMapBenchmark {
 
     private final DirectString utf16String = new DirectString();
     private final DirectUtf8String utf8String = new DirectUtf8String();
-    @Param({"16", "256", "1024"})
+    @Param({"256"})
+//    @Param({"16", "256", "1024"})
     private int n;
-    @Param({"5", "7", "31", "63"})
+    @Param({"5", /*"7", "31", "63" */})
     private int prefixLength;
     private long[] utf16Addresses;
+    private long[] utf16OffheapAddresses;
     private CharSequenceIntHashMap utf16Map = new CharSequenceIntHashMap();
+    private OffHeapCharSequenceIntHashMap utf16OffheapMap = new OffHeapCharSequenceIntHashMap();
     private DirectUtf16Sink utf16Sink;
+    private DirectUtf16Sink utf16OffHeapSink;
     private long[] utf8Addresses;
     private Utf8StringIntHashMap utf8Map = new Utf8StringIntHashMap();
     private DirectUtf8Sink utf8Sink;
@@ -68,24 +74,33 @@ public class Utf8StringIntHashMapBenchmark {
     public void setUp() {
         utf8Sink = new DirectUtf8Sink(2 * n * prefixLength);
         utf16Sink = new DirectUtf16Sink(4 * n * prefixLength);
+        utf16OffHeapSink = new DirectUtf16Sink(4 * n * prefixLength);
+
         utf8Addresses = new long[n + 1];
         utf16Addresses = new long[n + 1];
+        utf16OffheapAddresses = new long[n + 1];
+
         utf8Addresses[0] = utf8Sink.ptr();
         utf16Addresses[0] = utf16Sink.ptr();
+        utf16OffheapAddresses[0] = utf16Sink.ptr();
         for (int i = 0; i < n; i++) {
-            // The keys have identical prefix, but different suffixes.
+            // The keys have identical prefix but different suffixes.
             for (int j = 0; j < prefixLength; j++) {
                 utf8Sink.put('a');
                 utf16Sink.put('a');
+                utf16OffHeapSink.put('a');
             }
             utf8Sink.put(i);
             utf16Sink.put(i);
+            utf16OffHeapSink.put(i);
 
             utf8Map.put(Utf8String.newInstance(utf8Sink), 42);
             utf16Map.put(utf16Sink.toString(), 42);
+            utf16OffheapMap.put(utf16OffHeapSink.toString(), 42);
 
             utf8Addresses[i + 1] = utf8Sink.ptr() + utf8Sink.size();
             utf16Addresses[i + 1] = utf16Sink.ptr() + utf16Sink.size();
+            utf16OffheapAddresses[i + 1] = utf16OffHeapSink.ptr() + utf16OffHeapSink.size();
         }
     }
 
@@ -93,12 +108,32 @@ public class Utf8StringIntHashMapBenchmark {
     public void tearDown() {
         utf8Sink = Misc.free(utf8Sink);
         utf16Sink = Misc.free(utf16Sink);
+        utf16OffheapMap.clear();
         utf8Map = new Utf8StringIntHashMap();
         utf16Map = new CharSequenceIntHashMap();
+        utf16OffheapMap = new OffHeapCharSequenceIntHashMap();
     }
 
     @Benchmark
-    public long testUtf16Map() {
+    public int testUtf8Map_get() {
+        int sum = 0;
+        for (int i = 0; i < n; i++) {
+            sum += utf8Map.get(utf8String.of(utf8Addresses[i], utf8Addresses[i + 1]));
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long testUtf16OffHeapMap_get() {
+        int sum = 0;
+        for (int i = 0; i < n; i++) {
+            sum += utf16OffheapMap.get(utf16String.of(utf16Addresses[i], utf16Addresses[i + 1]));
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long testUtf16Map_get() {
         int sum = 0;
         for (int i = 0; i < n; i++) {
             sum += utf16Map.get(utf16String.of(utf16Addresses[i], utf16Addresses[i + 1]));
@@ -107,11 +142,14 @@ public class Utf8StringIntHashMapBenchmark {
     }
 
     @Benchmark
-    public int testUtf8Map() {
-        int sum = 0;
-        for (int i = 0; i < n; i++) {
-            sum += utf8Map.get(utf8String.of(utf8Addresses[i], utf8Addresses[i + 1]));
-        }
-        return sum;
+    public void testUtf16OffHeapMap_put(Blackhole b) {
+        int i = n / 2;
+        b.consume(utf16OffheapMap.put(utf16String.of(utf16Addresses[i], utf16Addresses[i + 1]), i));
+    }
+
+    @Benchmark
+    public void testUtf16Map_put(Blackhole b) {
+        int i = n / 2;
+        b.consume(utf16Map.put(utf16String.of(utf16Addresses[i], utf16Addresses[i + 1]), i));
     }
 }

--- a/benchmarks/src/main/java/org/questdb/Utf8StringIntHashMapBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/Utf8StringIntHashMapBenchmark.java
@@ -45,10 +45,11 @@ public class Utf8StringIntHashMapBenchmark {
 
     private final DirectString utf16String = new DirectString();
     private final DirectUtf8String utf8String = new DirectUtf8String();
-    @Param({"256"})
+    @Param({"16"})
 //    @Param({"16", "256", "1024"})
     private int n;
-    @Param({"5", /*"7", "31", "63" */})
+    @Param({"7"})
+//    @Param({"5", "7", "31", "63"})
     private int prefixLength;
     private long[] utf16Addresses;
     private long[] utf16OffheapAddresses;

--- a/core/src/main/java/io/questdb/cairo/wal/WalEventWriter.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalEventWriter.java
@@ -232,7 +232,7 @@ class WalEventWriter implements Closeable {
 
                     int symbolCount = 0;
                     for (int j = 0; j < size; j++) {
-                        final CharSequence symbol = symbolMap.keys()[j];
+                        final CharSequence symbol = symbolMap.getKeyQuick(j);
                         assert symbol != null;
                         final int value = symbolMap.get(symbol);
                         // Ignore symbols cached from symbolMapReader

--- a/core/src/main/java/io/questdb/cairo/wal/WalEventWriter.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalEventWriter.java
@@ -232,7 +232,7 @@ class WalEventWriter implements Closeable {
 
                     int symbolCount = 0;
                     for (int j = 0; j < size; j++) {
-                        final CharSequence symbol = symbolMap.keys().getQuick(j);
+                        final CharSequence symbol = symbolMap.keys()[j];
                         assert symbol != null;
                         final int value = symbolMap.get(symbol);
                         // Ignore symbols cached from symbolMapReader

--- a/core/src/main/java/io/questdb/cairo/wal/WalEventWriter.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalEventWriter.java
@@ -41,6 +41,7 @@ import io.questdb.std.FilesFacade;
 import io.questdb.std.MemoryTag;
 import io.questdb.std.Numbers;
 import io.questdb.std.ObjList;
+import io.questdb.std.OffHeapCharSequenceIntHashMap;
 import io.questdb.std.Rnd;
 import io.questdb.std.str.Path;
 import io.questdb.std.str.StringSink;
@@ -60,7 +61,7 @@ class WalEventWriter implements Closeable {
     private long startOffset = 0;
     private BoolList symbolMapNullFlags;
     private int txn = 0;
-    private ObjList<CharSequenceIntHashMap> txnSymbolMaps;
+    private ObjList<OffHeapCharSequenceIntHashMap> txnSymbolMaps;
 
     WalEventWriter(CairoConfiguration configuration) {
         this.configuration = configuration;
@@ -217,7 +218,7 @@ class WalEventWriter implements Closeable {
     private void writeSymbolMapDiffs() {
         final int columns = txnSymbolMaps.size();
         for (int columnIndex = 0; columnIndex < columns; columnIndex++) {
-            final CharSequenceIntHashMap symbolMap = txnSymbolMaps.getQuick(columnIndex);
+            final OffHeapCharSequenceIntHashMap symbolMap = txnSymbolMaps.getQuick(columnIndex);
             if (symbolMap != null) {
                 final int initialCount = initialSymbolCounts.get(columnIndex);
                 if (initialCount > 0 || (initialCount == 0 && symbolMap.size() > 0)) {
@@ -307,7 +308,7 @@ class WalEventWriter implements Closeable {
         return txn++;
     }
 
-    void of(ObjList<CharSequenceIntHashMap> txnSymbolMaps, AtomicIntList initialSymbolCounts, BoolList symbolMapNullFlags) {
+    void of(ObjList<OffHeapCharSequenceIntHashMap> txnSymbolMaps, AtomicIntList initialSymbolCounts, BoolList symbolMapNullFlags) {
         this.txnSymbolMaps = txnSymbolMaps;
         this.initialSymbolCounts = initialSymbolCounts;
         this.symbolMapNullFlags = symbolMapNullFlags;

--- a/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
@@ -77,6 +77,7 @@ import io.questdb.std.MemoryTag;
 import io.questdb.std.Misc;
 import io.questdb.std.Numbers;
 import io.questdb.std.ObjList;
+import io.questdb.std.OffHeapCharSequenceIntHashMap;
 import io.questdb.std.Os;
 import io.questdb.std.Utf8StringIntHashMap;
 import io.questdb.std.Uuid;
@@ -126,7 +127,7 @@ public class WalWriter implements TableWriterAPI {
     private final TableSequencerAPI sequencer;
     private final BoolList symbolMapNullFlags = new BoolList();
     private final ObjList<SymbolMapReader> symbolMapReaders = new ObjList<>();
-    private final ObjList<CharSequenceIntHashMap> symbolMaps = new ObjList<>();
+    private final ObjList<OffHeapCharSequenceIntHashMap> symbolMaps = new ObjList<>();
     private final int timestampIndex;
     private final ObjList<Utf8StringIntHashMap> utf8SymbolMaps = new ObjList<>();
     private final Uuid uuid = new Uuid();
@@ -1003,7 +1004,7 @@ public class WalWriter implements TableWriterAPI {
         initialSymbolCounts.extendAndSet(columnWriterIndex, 0);
         localSymbolIds.extendAndSet(columnWriterIndex, 0);
         symbolMapNullFlags.extendAndSet(columnWriterIndex, false);
-        symbolMaps.extendAndSet(columnWriterIndex, new CharSequenceIntHashMap(8, 0.5, SymbolTable.VALUE_NOT_FOUND));
+        symbolMaps.extendAndSet(columnWriterIndex, new OffHeapCharSequenceIntHashMap(8, 0.5, SymbolTable.VALUE_NOT_FOUND));
         utf8SymbolMaps.extendAndSet(columnWriterIndex, new Utf8StringIntHashMap(8, 0.5, SymbolTable.VALUE_NOT_FOUND));
     }
 
@@ -1092,7 +1093,7 @@ public class WalWriter implements TableWriterAPI {
         );
 
         symbolMapReaders.extendAndSet(columnWriterIndex, symbolMapReader);
-        symbolMaps.extendAndSet(columnWriterIndex, new CharSequenceIntHashMap(8, 0.5, SymbolTable.VALUE_NOT_FOUND));
+        symbolMaps.extendAndSet(columnWriterIndex, new OffHeapCharSequenceIntHashMap(8, 0.5, SymbolTable.VALUE_NOT_FOUND));
         utf8SymbolMaps.extendAndSet(columnWriterIndex, new Utf8StringIntHashMap(8, 0.5, SymbolTable.VALUE_NOT_FOUND));
         initialSymbolCounts.extendAndSet(columnWriterIndex, symbolCount);
         localSymbolIds.extendAndSet(columnWriterIndex, 0);
@@ -1524,7 +1525,7 @@ public class WalWriter implements TableWriterAPI {
     private void resetSymbolMaps() {
         final int numOfColumns = symbolMaps.size();
         for (int i = 0; i < numOfColumns; i++) {
-            final CharSequenceIntHashMap symbolMap = symbolMaps.getQuick(i);
+            final OffHeapCharSequenceIntHashMap symbolMap = symbolMaps.getQuick(i);
             if (symbolMap != null) {
                 symbolMap.clear();
             }
@@ -1731,7 +1732,7 @@ public class WalWriter implements TableWriterAPI {
     private static class ConversionSymbolMapWriter implements SymbolMapWriterLite {
         private int columnIndex;
         private IntList localSymbolIds;
-        private CharSequenceIntHashMap symbolHashMap;
+        private OffHeapCharSequenceIntHashMap symbolHashMap;
         private SymbolMapReader symbolMapReader;
 
         @Override
@@ -1742,7 +1743,7 @@ public class WalWriter implements TableWriterAPI {
         private int putSym0(int columnIndex, CharSequence utf16Value, SymbolMapReader symbolMapReader) {
             int key;
             if (utf16Value != null) {
-                final CharSequenceIntHashMap utf16Map = symbolHashMap;
+                final OffHeapCharSequenceIntHashMap utf16Map = symbolHashMap;
                 final int index = utf16Map.keyIndex(utf16Value);
                 if (index > -1) {
                     key = symbolMapReader.keyOf(utf16Value);
@@ -1774,7 +1775,7 @@ public class WalWriter implements TableWriterAPI {
     private static class ConversionSymbolTable implements SymbolTable {
         private final IntList symbols = new IntList();
         private int symbolCountWatermark;
-        private CharSequenceIntHashMap symbolHashMap;
+        private OffHeapCharSequenceIntHashMap symbolHashMap;
         private SymbolMapReader symbolMapReader;
 
         @Override
@@ -2484,7 +2485,7 @@ public class WalWriter implements TableWriterAPI {
         private int putSym0(int columnIndex, CharSequence utf16Value, SymbolMapReader symbolMapReader) {
             int key;
             if (utf16Value != null) {
-                final CharSequenceIntHashMap utf16Map = symbolMaps.getQuick(columnIndex);
+                final OffHeapCharSequenceIntHashMap utf16Map = symbolMaps.getQuick(columnIndex);
                 final int index = utf16Map.keyIndex(utf16Value);
                 if (index > -1) {
                     key = symbolMapReader.keyOf(utf16Value);

--- a/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
@@ -1792,7 +1792,7 @@ public class WalWriter implements TableWriterAPI {
                 return symbolMapReader.valueOf(key);
             } else {
                 int keyIndex = symbols.get(key - symbolCountWatermark);
-                return symbolHashMap.keys().get(keyIndex);
+                return symbolHashMap.keys()[keyIndex];
             }
         }
 
@@ -1807,7 +1807,7 @@ public class WalWriter implements TableWriterAPI {
             if (remapSize > 0) {
                 symbols.setPos(remapSize);
                 for (int i = 0, n = symbolHashMap.size(); i < n; i++) {
-                    CharSequence symbolValue = symbolHashMap.keys().get(i);
+                    CharSequence symbolValue = symbolHashMap.keys()[i];
                     int index = symbolHashMap.get(symbolValue);
                     if (index >= symbolCountWatermark) {
                         symbols.extendAndSet(index - symbolCountWatermark, i);

--- a/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
@@ -1792,7 +1792,7 @@ public class WalWriter implements TableWriterAPI {
                 return symbolMapReader.valueOf(key);
             } else {
                 int keyIndex = symbols.get(key - symbolCountWatermark);
-                return symbolHashMap.keys()[keyIndex];
+                return symbolHashMap.getKey(keyIndex);
             }
         }
 
@@ -1807,7 +1807,7 @@ public class WalWriter implements TableWriterAPI {
             if (remapSize > 0) {
                 symbols.setPos(remapSize);
                 for (int i = 0, n = symbolHashMap.size(); i < n; i++) {
-                    CharSequence symbolValue = symbolHashMap.keys()[i];
+                    CharSequence symbolValue = symbolHashMap.getKey(i);
                     int index = symbolHashMap.get(symbolValue);
                     if (index >= symbolCountWatermark) {
                         symbols.extendAndSet(index - symbolCountWatermark, i);

--- a/core/src/main/java/io/questdb/std/OffHeapCharSequenceIntHashMap.java
+++ b/core/src/main/java/io/questdb/std/OffHeapCharSequenceIntHashMap.java
@@ -1,0 +1,235 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.std;
+
+import io.questdb.std.str.DirectUtf16Sink;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.Closeable;
+import java.util.Arrays;
+
+/**
+ * A hash map that stores CharSequence keys off-heap and integers as value.
+ * This implementation uses a DirectUtf16Sink as view to off-heap string as key,
+ * allowing for efficient memory usage and manipulation.
+ */
+public class OffHeapCharSequenceIntHashMap extends AbstractCharSequenceHashSet implements Closeable {
+    public static final int NO_ENTRY_VALUE = -1;
+    protected static final DirectUtf16Sink noEntryKey = null;
+
+    protected IntList keyIndices;
+    protected int[] values;
+
+    public OffHeapCharSequenceIntHashMap() {
+        this(8);
+    }
+
+    public OffHeapCharSequenceIntHashMap(int initialCapacity) {
+        this(initialCapacity, 0.4);
+    }
+
+    public OffHeapCharSequenceIntHashMap(int initialCapacity, double loadFactor) {
+        super(initialCapacity, loadFactor);
+
+        int len = Numbers.ceilPow2((int) (this.capacity / loadFactor));
+
+        // Re-create keys with the specific type
+        keys = new DirectUtf16Sink[len];
+        values = new int[len];
+        keyIndices = new IntList(len);
+
+        // Initialize free variable
+        Arrays.fill(keys, noEntryKey);
+        Arrays.fill(values, NO_ENTRY_VALUE);
+        free = capacity;
+    }
+
+    @Override
+    public void clear() {
+        // Close all DirectUtf16Sink instances
+        for (DirectUtf16Sink key : (DirectUtf16Sink[]) keys) {
+            if (key != null) {
+                key.close();
+            }
+        }
+        Arrays.fill(keys, noEntryKey);
+        Arrays.fill(values, NO_ENTRY_VALUE);
+        keyIndices.clear();
+        free = capacity;
+    }
+
+    public void close() {
+        clear();
+    }
+
+    public int get(@NotNull CharSequence key) {
+        return valueAt(keyIndex(key));
+    }
+
+    /**
+     * Returns the list of keys.
+     * This list is a snapshot of the keys, which is copied
+     */
+    public ObjList<CharSequence> keys() {
+        ObjList<CharSequence> list = new ObjList<>(keyIndices.size());
+        for (int i = 0; i < keyIndices.size(); i++) {
+            int index = keyIndices.getQuick(i);
+            list.add(keys[index]);
+        }
+        return list;
+    }
+
+    public boolean put(@NotNull CharSequence key, int value) {
+        return putAt(keyIndex(key), key, value);
+    }
+
+    public void putAll(@NotNull OffHeapCharSequenceIntHashMap other) {
+        DirectUtf16Sink[] otherKeys = (DirectUtf16Sink[]) other.keys;
+        int[] otherValues = other.values;
+        for (int i = 0, n = otherKeys.length; i < n; i++) {
+            if (otherKeys[i] != noEntryKey) {
+                put(otherKeys[i], otherValues[i]);
+            }
+        }
+    }
+
+    public boolean putAt(int index, @NotNull CharSequence key, int value) {
+        if (index < 0) {
+            values[-index - 1] = value;
+            return false;
+        }
+        putAt0(index, key, value);
+        return true;
+    }
+
+    public void putIfAbsent(@NotNull CharSequence key, int value) {
+        int index = keyIndex(key);
+        if (index > -1) {
+            putAt0(index, key, value);
+        }
+    }
+
+    public int valueAt(int index) {
+        int index1 = -index - 1;
+        return index < 0 ? values[index1] : NO_ENTRY_VALUE;
+    }
+
+    public int valueQuick(int index) {
+        if (index >= 0 && index < keyIndices.size()) {
+            int keyIndex = keyIndices.getQuick(index);
+            return values[keyIndex];
+        }
+        return NO_ENTRY_VALUE;
+    }
+
+    @Override
+    public int size() {
+        return keyIndices.size();
+    }
+
+    protected void erase(int index) {
+        DirectUtf16Sink key = (DirectUtf16Sink) keys[index];
+        if (key != null) {
+            // Remove the index from keyIndices
+            for (int i = 0; i < keyIndices.size(); i++) {
+                if (keyIndices.getQuick(i) == index) {
+                    keyIndices.remove(i);
+                    break;
+                }
+            }
+            // TODO: sink pooling?
+            // Note: very important to close the key to release off-heap memory and prevent memory leaks
+            key.close();
+        }
+        keys[index] = noEntryKey;
+        values[index] = NO_ENTRY_VALUE;
+    }
+
+    protected void move(int from, int to) {
+        keys[to] = keys[from];
+        values[to] = values[from];
+        keys[from] = noEntryKey;
+        values[from] = NO_ENTRY_VALUE;
+    }
+
+    /**
+     * Puts a key-value pair at the specified index, replacing an existing key at that index.
+     */
+    private DirectUtf16Sink putAt0(int index, CharSequence key, int value) {
+        DirectUtf16Sink sink;
+
+        // If there's already a key at this index, reuse it
+        DirectUtf16Sink oldKey = (DirectUtf16Sink) keys[index];
+        if (oldKey != null) {
+            // Remove the index from keyIndices
+            for (int i = 0; i < keyIndices.size(); i++) {
+                if (keyIndices.getQuick(i) == index) {
+                    keyIndices.remove(i);
+                    break;
+                }
+            }
+            // Reuse the existing sink instead of closing it
+            sink = oldKey;
+            sink.clear();
+            sink.put(key);
+        } else {
+            // TODO: take from pool if there's any allocated already?
+            sink = new DirectUtf16Sink(key.length());
+            sink.put(key);
+        }
+
+        keys[index] = sink;
+        keyIndices.add(index);
+        values[index] = value;
+        if (--free == 0) {
+            rehash();
+        }
+        return sink;
+    }
+
+    private void rehash() {
+        int[] oldValues = values;
+        DirectUtf16Sink[] oldKeys = (DirectUtf16Sink[]) keys;
+        int size = capacity - free;
+        capacity = capacity * 2;
+        free = capacity - size;
+        mask = Numbers.ceilPow2((int) (capacity / loadFactor)) - 1;
+        this.keys = new DirectUtf16Sink[mask + 1];
+        this.values = new int[mask + 1];
+
+        // Clear the keyIndices list before adding new indices
+        keyIndices.clear();
+
+        for (int i = oldKeys.length - 1; i > -1; i--) {
+            CharSequence key = oldKeys[i];
+            if (key != null) {
+                final int newIndex = keyIndex(key);
+                keys[newIndex] = oldKeys[i];
+                values[newIndex] = oldValues[i];
+                keyIndices.add(newIndex);
+            }
+        }
+    }
+}

--- a/core/src/main/java/io/questdb/std/OffHeapCharSequenceIntHashMap.java
+++ b/core/src/main/java/io/questdb/std/OffHeapCharSequenceIntHashMap.java
@@ -92,8 +92,26 @@ public class OffHeapCharSequenceIntHashMap extends AbstractCharSequenceHashSet i
         return valueAt(keyIndex(key));
     }
 
-    public CharSequence[] keys() {
-        return keys;
+
+    /**
+     * Accesses the key at the specified index with bounds check.
+     */
+    public CharSequence getKey(int index) {
+        if (index < keys.length) {
+            return keys[index];
+        }
+        throw new ArrayIndexOutOfBoundsException(index);
+    }
+
+    /**
+     * Accesses the key at the specified index without bounds check.
+     */
+    public CharSequence getKeyQuick(int index) {
+        if (index >= 0 && index < keyIndices.size()) {
+            int keyIndex = keyIndices.getQuick(index);
+            return keys[keyIndex];
+        }
+        return null;
     }
 
     public boolean put(@NotNull CharSequence key, int value) {

--- a/core/src/main/java/io/questdb/std/OffHeapCharSequenceIntHashMap.java
+++ b/core/src/main/java/io/questdb/std/OffHeapCharSequenceIntHashMap.java
@@ -37,11 +37,11 @@ import java.util.Arrays;
  */
 public class OffHeapCharSequenceIntHashMap extends AbstractCharSequenceHashSet implements Closeable {
     public static final int NO_ENTRY_VALUE = -1;
-    protected static final DirectUtf16Sink noEntryKey = null;
-    protected static final int noEntryValue = -1;
+    // Let's use a DirectUtf16Sink as the key type
+    private static final DirectUtf16Sink noEntryKey = null;
 
-    protected IntList keyIndices;
-    protected int[] values;
+    private final IntList keyIndices;
+    private int[] values;
 
     public OffHeapCharSequenceIntHashMap() {
         this(8);
@@ -92,17 +92,8 @@ public class OffHeapCharSequenceIntHashMap extends AbstractCharSequenceHashSet i
         return valueAt(keyIndex(key));
     }
 
-    /**
-     * Returns the list of keys.
-     * This list is a snapshot of the keys, which is copied
-     */
-    public ObjList<CharSequence> keys() {
-        ObjList<CharSequence> list = new ObjList<>(keyIndices.size());
-        for (int i = 0; i < keyIndices.size(); i++) {
-            int index = keyIndices.getQuick(i);
-            list.add(keys[index]);
-        }
-        return list;
+    public CharSequence[] keys() {
+        return keys;
     }
 
     public boolean put(@NotNull CharSequence key, int value) {

--- a/core/src/main/java/io/questdb/std/OffHeapCharSequenceIntHashMap.java
+++ b/core/src/main/java/io/questdb/std/OffHeapCharSequenceIntHashMap.java
@@ -38,6 +38,7 @@ import java.util.Arrays;
 public class OffHeapCharSequenceIntHashMap extends AbstractCharSequenceHashSet implements Closeable {
     public static final int NO_ENTRY_VALUE = -1;
     protected static final DirectUtf16Sink noEntryKey = null;
+    protected static final int noEntryValue = -1;
 
     protected IntList keyIndices;
     protected int[] values;
@@ -51,8 +52,11 @@ public class OffHeapCharSequenceIntHashMap extends AbstractCharSequenceHashSet i
     }
 
     public OffHeapCharSequenceIntHashMap(int initialCapacity, double loadFactor) {
-        super(initialCapacity, loadFactor);
+        this(initialCapacity, loadFactor, NO_ENTRY_VALUE);
+    }
 
+    public OffHeapCharSequenceIntHashMap(int initialCapacity, double loadFactor, int valueNotFound) {
+        super(initialCapacity, loadFactor);
         int len = Numbers.ceilPow2((int) (this.capacity / loadFactor));
 
         // Re-create keys with the specific type
@@ -62,7 +66,7 @@ public class OffHeapCharSequenceIntHashMap extends AbstractCharSequenceHashSet i
 
         // Initialize free variable
         Arrays.fill(keys, noEntryKey);
-        Arrays.fill(values, NO_ENTRY_VALUE);
+        Arrays.fill(values, valueNotFound);
         free = capacity;
     }
 

--- a/core/src/test/java/io/questdb/test/std/OffHeapCharSequenceIntHashMapTest.java
+++ b/core/src/test/java/io/questdb/test/std/OffHeapCharSequenceIntHashMapTest.java
@@ -1,0 +1,335 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.std;
+
+import io.questdb.std.OffHeapCharSequenceIntHashMap;
+import io.questdb.std.ObjList;
+import io.questdb.std.Rnd;
+import io.questdb.std.str.DirectUtf16Sink;
+import io.questdb.std.str.StringSink;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class OffHeapCharSequenceIntHashMapTest {
+    private OffHeapCharSequenceIntHashMap map;
+
+    private DirectUtf16Sink sink;
+
+    @Before
+    public void setUp() {
+        map = new OffHeapCharSequenceIntHashMap();
+    }
+
+    @After
+    public void tearDown() {
+        if (map != null) {
+            map.close();
+        }
+
+        if (sink != null) {
+            sink.close();
+        }
+    }
+
+    @Test
+    public void testInitialization() {
+        // Create a map with default parameters
+        map = new OffHeapCharSequenceIntHashMap();
+
+        // Create a sink to generate a string
+        sink = new DirectUtf16Sink(100);
+        for (int i = 0; i < 10; i++) {
+            sink.put('a');
+        }
+        sink.put(1);
+
+        // This should not throw an exception
+        map.put(sink.toString(), 42);
+
+        // Verify the value was stored correctly
+        Assert.assertEquals(42, map.get(sink.toString()));
+    }
+
+    @Test
+    public void testInitializationWithSmallCapacity() {
+        // Create a map with a small initial capacity
+        map = new OffHeapCharSequenceIntHashMap(1);
+
+        // Create a sink to generate a string
+        sink = new DirectUtf16Sink(100);
+        for (int i = 0; i < 10; i++) {
+            sink.put('a');
+        }
+        sink.put(1);
+
+        // This should not throw an exception
+        map.put(sink.toString(), 42);
+
+        // Verify the value was stored correctly
+        Assert.assertEquals(42, map.get(sink.toString()));
+    }
+
+    @Test
+    public void testInitializationWithLargeCapacity() {
+        // Create a map with a large initial capacity
+        map = new OffHeapCharSequenceIntHashMap(1000);
+
+        // Create a sink to generate a string
+        sink = new DirectUtf16Sink(100);
+        for (int i = 0; i < 10; i++) {
+            sink.put('a');
+        }
+        sink.put(1);
+
+        // This should not throw an exception
+        map.put(sink.toString(), 42);
+
+        // Verify the value was stored correctly
+        Assert.assertEquals(42, map.get(sink.toString()));
+    }
+
+    @Test
+    public void testGet() {
+        // Test getting values from an empty map
+        Assert.assertEquals(OffHeapCharSequenceIntHashMap.NO_ENTRY_VALUE, map.get("nonexistent"));
+
+        // Test getting values for existing keys
+        map.put("key1", 100);
+        map.put("key2", 200);
+        map.put("key3", 300);
+
+        Assert.assertEquals(100, map.get("key1"));
+        Assert.assertEquals(200, map.get("key2"));
+        Assert.assertEquals(300, map.get("key3"));
+
+        // Test getting values for non-existing keys
+        Assert.assertEquals(OffHeapCharSequenceIntHashMap.NO_ENTRY_VALUE, map.get("nonexistent"));
+
+        // Test getting values after keys have been removed
+        map.remove("key2");
+        Assert.assertEquals(100, map.get("key1"));
+        Assert.assertEquals(OffHeapCharSequenceIntHashMap.NO_ENTRY_VALUE, map.get("key2"));
+        Assert.assertEquals(300, map.get("key3"));
+    }
+
+    @Test
+    public void testClear() {
+        // Test clearing an empty map
+        map.clear();
+        Assert.assertEquals(0, map.size());
+
+        // Add some entries to the map
+        map.put("key1", 100);
+        map.put("key2", 200);
+        map.put("key3", 300);
+        Assert.assertEquals(3, map.size());
+
+        // Test clearing the map
+        map.clear();
+        Assert.assertEquals(0, map.size());
+
+        // Verify all keys are removed
+        Assert.assertEquals(OffHeapCharSequenceIntHashMap.NO_ENTRY_VALUE, map.get("key1"));
+        Assert.assertEquals(OffHeapCharSequenceIntHashMap.NO_ENTRY_VALUE, map.get("key2"));
+        Assert.assertEquals(OffHeapCharSequenceIntHashMap.NO_ENTRY_VALUE, map.get("key3"));
+    }
+
+    @Test
+    public void testRemove() {
+        // Test removing from an empty map
+        Assert.assertEquals(-1, map.remove("nonexistent"));
+        Assert.assertEquals(0, map.size());
+
+        // Add some entries to the map
+        map.put("key1", 100);
+        map.put("key2", 200);
+        map.put("key3", 300);
+        Assert.assertEquals(3, map.size());
+
+        // Test removing an existing key
+        int index = map.remove("key2");
+        Assert.assertTrue("Remove should return a valid index for an existing key", index >= 0);
+        Assert.assertEquals(2, map.size());
+        Assert.assertEquals(OffHeapCharSequenceIntHashMap.NO_ENTRY_VALUE, map.get("key2"));
+
+        // Test removing a non-existing key
+        Assert.assertEquals(-1, map.remove("nonexistent"));
+        Assert.assertEquals(2, map.size());
+
+        // Test removing the same key again
+        Assert.assertEquals(-1, map.remove("key2"));
+        Assert.assertEquals(2, map.size());
+    }
+
+    @Test
+    public void testPartialLookup() {
+        Rnd rnd = new Rnd();
+        final int N = 1000;
+
+        for (int i = 0; i < N; i++) {
+            String s = rnd.nextString(10).substring(1, 9);
+            map.put(s, i);
+        }
+
+        rnd.reset();
+
+        for (int i = 0; i < N; i++) {
+            CharSequence cs = rnd.nextString(10);
+            int index = map.keyIndex(cs, 1, 9);
+            Assert.assertEquals(i, map.valueAt(index));
+        }
+
+        rnd.reset();
+        for (int i = 0; i < N; i++) {
+            CharSequence cs = rnd.nextString(10);
+            Assert.assertFalse(map.excludes(cs, 1, 9));
+        }
+    }
+
+    @Test
+    public void testPutMutableCharSequence() {
+        StringSink ss = new StringSink();
+        ss.put("a");
+
+        map.putIfAbsent(ss, 1);
+
+        ss.clear();
+        ss.put("bb");
+
+        map.putIfAbsent(ss, 2);
+
+        Assert.assertEquals(1, map.get("a"));
+        Assert.assertEquals(2, map.get("bb"));
+
+        ObjList<CharSequence> keys = map.keys();
+        Assert.assertEquals(2, keys.size());
+        Assert.assertEquals("a", keys.get(0).toString());
+        Assert.assertEquals("bb", keys.get(1).toString());
+    }
+
+    @Test
+    public void testMemoryManagement() {
+        // Test that the map properly manages off-heap memory
+        final int N = 10000;
+        Rnd rnd = new Rnd();
+
+        // Add a large number of entries to force rehashing
+        for (int i = 0; i < N; i++) {
+            CharSequence cs = rnd.nextChars(50); // Larger strings to use more memory
+            map.put(cs, i);
+        }
+
+        // Verify all entries are accessible
+        rnd.reset();
+        for (int i = 0; i < N; i++) {
+            CharSequence cs = rnd.nextChars(50);
+            Assert.assertEquals(i, map.get(cs));
+        }
+
+        // Clear the map and verify it's empty
+        map.clear();
+        Assert.assertEquals(0, map.size());
+
+        // Add entries again to verify memory is reused
+        rnd.reset();
+        for (int i = 0; i < N; i++) {
+            CharSequence cs = rnd.nextChars(50);
+            map.put(cs, i * 2);
+        }
+
+        // Verify all entries are accessible with new values
+        rnd.reset();
+        for (int i = 0; i < N; i++) {
+            CharSequence cs = rnd.nextChars(50);
+            Assert.assertEquals(i * 2, map.get(cs));
+        }
+    }
+
+    @Test
+    public void testCloseAndRehash() {
+        // Test proper cleanup after close and behavior during rehashing
+        try (OffHeapCharSequenceIntHashMap tempMap = new OffHeapCharSequenceIntHashMap(16, 0.5)) {
+            // Fill the map to trigger rehashing
+            Rnd rnd = new Rnd();
+            for (int i = 0; i < 100; i++) {
+                tempMap.put(rnd.nextChars(20), i);
+            }
+
+            // Verify entries
+            rnd.reset();
+            for (int i = 0; i < 100; i++) {
+                Assert.assertEquals(i, tempMap.get(rnd.nextChars(20)));
+            }
+        }
+
+        // Create a new map after closing the previous one
+        try (OffHeapCharSequenceIntHashMap tempMap = new OffHeapCharSequenceIntHashMap()) {
+            Rnd rnd = new Rnd();
+            for (int i = 0; i < 50; i++) {
+                tempMap.put(rnd.nextChars(10), i);
+            }
+
+            // Verify entries
+            rnd.reset();
+            for (int i = 0; i < 50; i++) {
+                Assert.assertEquals(i, tempMap.get(rnd.nextChars(10)));
+            }
+        }
+    }
+
+    @Test
+    public void testPut() {
+        // Test putting a new key-value pair
+        boolean result = map.put("key1", 100);
+        Assert.assertTrue("Put should return true for a new key", result);
+        Assert.assertEquals(100, map.get("key1"));
+        Assert.assertEquals(1, map.size());
+
+        // Test updating an existing key with a new value
+        result = map.put("key1", 200);
+        Assert.assertFalse("Put should return false for an existing key", result);
+        Assert.assertEquals(200, map.get("key1"));
+        Assert.assertEquals(1, map.size());
+
+        // Test putting multiple key-value pairs
+        map.put("key2", 300);
+        map.put("key3", 400);
+        Assert.assertEquals(300, map.get("key2"));
+        Assert.assertEquals(400, map.get("key3"));
+        Assert.assertEquals(3, map.size());
+
+        // Test putting many key-value pairs to trigger rehashing
+        final int N = 1000;
+        for (int i = 0; i < N; i++) {
+            String key = "newkey" + i;
+            result = map.put(key, i);
+            Assert.assertTrue("Put should return true for a new key", result);
+            Assert.assertEquals(i, map.get(key));
+        }
+        Assert.assertEquals(N + 3, map.size()); // 1000 new keys + 3 existing keys
+    }
+}

--- a/core/src/test/java/io/questdb/test/std/OffHeapCharSequenceIntHashMapTest.java
+++ b/core/src/test/java/io/questdb/test/std/OffHeapCharSequenceIntHashMapTest.java
@@ -233,10 +233,9 @@ public class OffHeapCharSequenceIntHashMapTest {
         Assert.assertEquals(1, map.get("a"));
         Assert.assertEquals(2, map.get("bb"));
 
-        CharSequence[] keys = map.keys();
-        Assert.assertEquals(2, keys.length);
-        Assert.assertEquals("a", keys[0].toString());
-        Assert.assertEquals("bb", keys[1].toString());
+        Assert.assertEquals(2, map.size());
+        Assert.assertEquals("a", map.getKeyQuick(0).toString());
+        Assert.assertEquals("bb", map.getKeyQuick(1).toString());
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/std/OffHeapCharSequenceIntHashMapTest.java
+++ b/core/src/test/java/io/questdb/test/std/OffHeapCharSequenceIntHashMapTest.java
@@ -24,25 +24,19 @@
 
 package io.questdb.test.std;
 
-import io.questdb.std.OffHeapCharSequenceIntHashMap;
 import io.questdb.std.ObjList;
+import io.questdb.std.OffHeapCharSequenceIntHashMap;
 import io.questdb.std.Rnd;
 import io.questdb.std.str.DirectUtf16Sink;
 import io.questdb.std.str.StringSink;
 import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 public class OffHeapCharSequenceIntHashMapTest {
     private OffHeapCharSequenceIntHashMap map;
 
     private DirectUtf16Sink sink;
-
-    @Before
-    public void setUp() {
-        map = new OffHeapCharSequenceIntHashMap();
-    }
 
     @After
     public void tearDown() {
@@ -76,6 +70,8 @@ public class OffHeapCharSequenceIntHashMapTest {
 
     @Test
     public void testInitializationWithSmallCapacity() {
+        map = new OffHeapCharSequenceIntHashMap();
+
         // Create a map with a small initial capacity
         map = new OffHeapCharSequenceIntHashMap(1);
 
@@ -95,6 +91,8 @@ public class OffHeapCharSequenceIntHashMapTest {
 
     @Test
     public void testInitializationWithLargeCapacity() {
+        map = new OffHeapCharSequenceIntHashMap();
+
         // Create a map with a large initial capacity
         map = new OffHeapCharSequenceIntHashMap(1000);
 
@@ -114,6 +112,8 @@ public class OffHeapCharSequenceIntHashMapTest {
 
     @Test
     public void testGet() {
+        map = new OffHeapCharSequenceIntHashMap();
+
         // Test getting values from an empty map
         Assert.assertEquals(OffHeapCharSequenceIntHashMap.NO_ENTRY_VALUE, map.get("nonexistent"));
 
@@ -138,6 +138,8 @@ public class OffHeapCharSequenceIntHashMapTest {
 
     @Test
     public void testClear() {
+        map = new OffHeapCharSequenceIntHashMap();
+
         // Test clearing an empty map
         map.clear();
         Assert.assertEquals(0, map.size());
@@ -160,6 +162,8 @@ public class OffHeapCharSequenceIntHashMapTest {
 
     @Test
     public void testRemove() {
+        map = new OffHeapCharSequenceIntHashMap();
+
         // Test removing from an empty map
         Assert.assertEquals(-1, map.remove("nonexistent"));
         Assert.assertEquals(0, map.size());
@@ -187,6 +191,8 @@ public class OffHeapCharSequenceIntHashMapTest {
 
     @Test
     public void testPartialLookup() {
+        map = new OffHeapCharSequenceIntHashMap();
+
         Rnd rnd = new Rnd();
         final int N = 1000;
 
@@ -212,6 +218,8 @@ public class OffHeapCharSequenceIntHashMapTest {
 
     @Test
     public void testPutMutableCharSequence() {
+        map = new OffHeapCharSequenceIntHashMap();
+
         StringSink ss = new StringSink();
         ss.put("a");
 
@@ -225,14 +233,16 @@ public class OffHeapCharSequenceIntHashMapTest {
         Assert.assertEquals(1, map.get("a"));
         Assert.assertEquals(2, map.get("bb"));
 
-        ObjList<CharSequence> keys = map.keys();
-        Assert.assertEquals(2, keys.size());
-        Assert.assertEquals("a", keys.get(0).toString());
-        Assert.assertEquals("bb", keys.get(1).toString());
+        CharSequence[] keys = map.keys();
+        Assert.assertEquals(2, keys.length);
+        Assert.assertEquals("a", keys[0].toString());
+        Assert.assertEquals("bb", keys[1].toString());
     }
 
     @Test
     public void testMemoryManagement() {
+        map = new OffHeapCharSequenceIntHashMap();
+
         // Test that the map properly manages off-heap memory
         final int N = 10000;
         Rnd rnd = new Rnd();
@@ -271,6 +281,8 @@ public class OffHeapCharSequenceIntHashMapTest {
 
     @Test
     public void testCloseAndRehash() {
+        map = new OffHeapCharSequenceIntHashMap();
+
         // Test proper cleanup after close and behavior during rehashing
         try (OffHeapCharSequenceIntHashMap tempMap = new OffHeapCharSequenceIntHashMap(16, 0.5)) {
             // Fill the map to trigger rehashing
@@ -303,6 +315,8 @@ public class OffHeapCharSequenceIntHashMapTest {
 
     @Test
     public void testPut() {
+        map = new OffHeapCharSequenceIntHashMap();
+
         // Test putting a new key-value pair
         boolean result = map.put("key1", 100);
         Assert.assertTrue("Put should return true for a new key", result);


### PR DESCRIPTION
This patch introduces the implementation of the `OffHeapCharSequenceIntHashMap.java`, where `CharSequence` content is located off-heap. Specifically, we leverage the possibilities of `DirectUtf16Sink` as a view to a key string.

All necessary tests as well as benchmarks were implemented, and on-heap implementation was replaced with off-heap solution in `WalWriter`.  No memory leaks were observed during the testing process.

Considered tradeoffs and potential improvements so far.
1. Use a hand-written view class for keys instead of `DirectUtf16Sink`, purely due to time constraints. The most optimal way is to store the memory address and the length of the record (in bytes).
2. We can go further and don't free off-heap memory immediately in case of a single `remove`, but keep some part in the pool.  Theoretically, we can have a data structure which would help to control the single 'off-heap heap' :)
3. I saw a hash code caching in `Utf8StringIntHashMap`. This is also applicable here to reduce computation time, but it was not implemented due to time constraints.